### PR TITLE
Fix pip install

### DIFF
--- a/mongo_db_from_config/mongo_db_from_config.py
+++ b/mongo_db_from_config/mongo_db_from_config.py
@@ -1,8 +1,3 @@
-# third-party libraries (install with pip)
-from pymongo import MongoClient
-import yaml
-
-
 def db_from_config(config_filename):
     """Create a MongoClient database connection from a YAML config file.
 
@@ -20,6 +15,10 @@ def db_from_config(config_filename):
     -------
     mongokit.database.Database: The Mongo database connection
     """
+    # third-party libraries (install with pip)
+    from pymongo import MongoClient
+    import yaml
+
     db = None
 
     with open(config_filename, "r") as stream:


### PR DESCRIPTION
pip was failing to install this package from github with an error like this:
```
❱ pip install https://github.com/cisagov/mongo-db-from-config/tarball/develop
Collecting https://github.com/cisagov/mongo-db-from-config/tarball/develop
  Downloading https://github.com/cisagov/mongo-db-from-config/tarball/develop
     - 10kB 646kB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/n2/bgdyrrb15ys03yljp616k7c00000gq/T/pip-req-build-5lttkp74/setup.py", line 11, in <module>
        from mongo_db_from_config import __version__
      File "/private/var/folders/n2/bgdyrrb15ys03yljp616k7c00000gq/T/pip-req-build-5lttkp74/mongo_db_from_config/__init__.py", line 1, in <module>
        from .mongo_db_from_config import db_from_config
      File "/private/var/folders/n2/bgdyrrb15ys03yljp616k7c00000gq/T/pip-req-build-5lttkp74/mongo_db_from_config/mongo_db_from_config.py", line 2, in <module>
        from pymongo import MongoClient
    ModuleNotFoundError: No module named 'pymongo'
```

The fix is to move the import statements inside `db_from_config()` so that pip does not evaluate them until after the required packages have been installed. If there's a better solution to this problem, I'm all ears.