### PR TITLE
Make bump_version.sh work on Mac and Linux

### DIFF
--- a/bump_version.sh
+++ b/bump_version.sh
@@ -20,7 +20,9 @@ else
         major|minor|patch|prerelease|build)
             new_version=$(python -c "import semver; print(semver.bump_$1('$old_version'))")
             echo Changing version from "$old_version" to "$new_version"
-            sed "s/$old_version/$new_version/" $VERSION_FILE > >(sleep 1 && cat > $VERSION_FILE)
+            tmp_file=/tmp/version.$$
+            sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+            mv $tmp_file $VERSION_FILE
             git add $VERSION_FILE
             git commit -m"Bump version from $old_version to $new_version"
             git push
@@ -28,7 +30,9 @@ else
         finalize)
             new_version=$(python -c "import semver; print(semver.finalize_version('$old_version'))")
             echo Changing version from "$old_version" to "$new_version"
-            sed "s/$old_version/$new_version/" $VERSION_FILE > >(sleep 1 && cat > $VERSION_FILE)
+            tmp_file=/tmp/version.$$
+            sed "s/$old_version/$new_version/" $VERSION_FILE > $tmp_file
+            mv $tmp_file $VERSION_FILE
             git add $VERSION_FILE
             git commit -m"Finalize version from $old_version to $new_version"
             git push

--- a/bump_version.sh
+++ b/bump_version.sh
@@ -10,7 +10,7 @@ VERSION_FILE=mongo_db_from_config/__init__.py
 
 HELP_INFORMATION="bump_version.sh (show|major|minor|patch|prerelease|build|finalize)"
 
-old_version=$(sed -n "s/^__version__ = '\(.*\)'$/\1/p" $VERSION_FILE)
+old_version=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' $VERSION_FILE)
 
 if [ $# -ne 1 ]
 then
@@ -20,7 +20,7 @@ else
         major|minor|patch|prerelease|build)
             new_version=$(python -c "import semver; print(semver.bump_$1('$old_version'))")
             echo Changing version from "$old_version" to "$new_version"
-            sed -i "s/$old_version/$new_version/" $VERSION_FILE
+            sed "s/$old_version/$new_version/" $VERSION_FILE > >(sleep 1 && cat > $VERSION_FILE)
             git add $VERSION_FILE
             git commit -m"Bump version from $old_version to $new_version"
             git push
@@ -28,7 +28,7 @@ else
         finalize)
             new_version=$(python -c "import semver; print(semver.finalize_version('$old_version'))")
             echo Changing version from "$old_version" to "$new_version"
-            sed -i "s/$old_version/$new_version/" $VERSION_FILE
+            sed "s/$old_version/$new_version/" $VERSION_FILE > >(sleep 1 && cat > $VERSION_FILE)
             git add $VERSION_FILE
             git commit -m"Finalize version from $old_version to $new_version"
             git push


### PR DESCRIPTION
This is a somewhat hacky solution (due to the use of `sleep 1`), but it gets the job done.

It uses bash process substitution, rather than sed in-place replacement, to modify the version string.

This is necessary because Mac OS X ships with BSD sed, rather than GNU sed (used by Linux), and they have incompatible options for in-place replacements.

Thoughts?

Also note that since we are using `black` with our pre-commits, I had to modify the sed regex that determines the initial (pre-bump) version so that it looks for the version string in double-quotes (which `black` enforces), rather than single-quotes.