### PR TITLE
Fix two typos in a comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires = [
     #
     # setuptools>=68.0.0 was the last version to support Python 3.7.
     #
-    # setuptools>=65.3.2 was the last version to support Python 3.7.
+    # setuptools>=75.3.2 was the last version to support Python 3.8.
     "setuptools>=68.0.0; python_version == '3.7'",
     "setuptools>=75.3.2; python_version == '3.8'",
     "setuptools>=77.0.0; python_version >= '3.9'",


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request fixes two typos in a comment.

## 💭 Motivation and context ##

Correctness is next to godliness!

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.