### PR TITLE
Revert overly ambitious `pyupgrade` changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,8 +195,12 @@ repos:
           # version or later.  See here for more details:
           # https://www.gyford.com/phil/writing/2025/08/26/how-to-use-pyupgrade/
           #
-          # As this library must support Python 3.7, we do not want to
-          # apply any upgrades for Python versions beyond that.
+          # This library must support Python 3.7 since in
+          # cisagov/cyhy_amis it is being used on Debian Buster (see,
+          # e.g., reporter_ami_x86_64.pkr.hcl), which doesn't offer
+          # any version of Python 3 beyond 3.7.  Therefore we do not
+          # want to apply any upgrades for Python versions beyond
+          # that.
           - --py37-plus
 
   # Ansible hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -194,7 +194,10 @@ repos:
           # Python, so we want to apply all rules that apply to this
           # version or later.  See here for more details:
           # https://www.gyford.com/phil/writing/2025/08/26/how-to-use-pyupgrade/
-          - --py310-plus
+          #
+          # As this library must support Python 3.7, we do not want to
+          # apply any upgrades for Python versions beyond that.
+          - --py37-plus
 
   # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint

--- a/src/mongo_db_from_config/mongo_db_from_config.py
+++ b/src/mongo_db_from_config/mongo_db_from_config.py
@@ -1,5 +1,8 @@
 """This module contains the mongo_db_from_config code."""
 
+# Standard Python Libraries
+from typing import Dict
+
 # Third-Party Libraries
 import pymongo
 import yaml
@@ -37,7 +40,7 @@ def db_from_config(config_filename: str) -> pymongo.database.Database:
         # The loader must now be explicitly specified to avoid a
         # warning message.  See here for more details:
         # https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
-        config: dict[str, dict[str, str]] = yaml.load(stream, Loader=yaml.SafeLoader)
+        config: Dict[str, Dict[str, str]] = yaml.load(stream, Loader=yaml.SafeLoader)
 
     db_uri: str = config["database"]["uri"]
     db_name: str = config["database"]["name"]


### PR DESCRIPTION
## 🗣 Description ##

This pull request reverts some overly ambitious `pyupgrade` changes from #36.

## 💭 Motivation and context ##

As this repo must support Python 3.7, we must restrict `pyupgrade` upgrades to Python 3.7 and earlier.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.