### PR TITLE
Add an upper bound pin for `setuptools`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ test = [
     "pytest-cov",
     "pytest",
     # This is a hidden dependency of mongomock, and it is not
-    # otherwise present under Python 3.12 and later.
+    # installed by default under Python 3.12 and later.
     #
     # The versions of mongomock that we allow make use of
     # pkg_resources, which was removed in setuptools>=82, so this is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,11 @@ test = [
     "pytest",
     # This is a hidden dependency of mongomock, and it is not
     # otherwise present under Python 3.12 and later.
-    "setuptools; python_version >= '3.12'",
+    #
+    # The versions of mongomock that we allow make use of
+    # pkg_resources, which was removed in setuptools>=82, so this is
+    # the reason for the upper bound pin.
+    "setuptools<82",
 ]
 
 [project.urls]


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds an upper bound pin for `setuptools` in the testing requirements.

## 💭 Motivation and context ##

The versions of `mongomock` that we allow make use of `pkg_resources`, which was removed in `setuptools>=82`.

## 🧪 Testing ##

All automated tests pass.  They [do not pass](https://github.com/cisagov/mongo-db-from-config/actions/runs/21970206955) without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.